### PR TITLE
json-bigintの使う箇所を制限する

### DIFF
--- a/src/domain/convertTweetToSummary.ts
+++ b/src/domain/convertTweetToSummary.ts
@@ -1,9 +1,6 @@
 import { SettledPromiseValue, StoreSummary, TweetEntity } from "../contract";
+import { bigIntToStringReviver } from "../util";
 import { IParseEntryFromUrl } from "./parseEntryFromUrl";
-const JSONBig: {
-  stringify: typeof JSON.stringify;
-  parse: typeof JSON.parse;
-} = require("json-bigint");
 
 export const convertToTweetToSummary = (
   urlDetectors: Array<IParseEntryFromUrl>
@@ -25,14 +22,24 @@ export const convertToTweetToSummary = (
     .then((v) => new Set(v));
 
   if (entryUrl.size === 0) {
-    console.error(`could not detect entry url: ${JSONBig.stringify(entity)}`);
+    console.error(
+      `could not detect entry url: ${JSON.stringify(
+        entity,
+        bigIntToStringReviver
+      )}`
+    );
     return Promise.resolve({
       status: "rejected",
       value: entity,
     });
   }
   if (entryUrl.size > 1) {
-    console.warn(`multiple entry url detected: ${JSONBig.stringify(entity)}`);
+    console.warn(
+      `multiple entry url detected: ${JSON.stringify(
+        entity,
+        bigIntToStringReviver
+      )}`
+    );
   }
 
   return Promise.resolve({

--- a/src/infrastructure/file.ts
+++ b/src/infrastructure/file.ts
@@ -1,4 +1,5 @@
 import { readFile, writeFile } from "fs";
+import JSONBig from "json-bigint";
 import {
   IFailedEntityStorable,
   IRawEntitiesDumpable,
@@ -11,10 +12,8 @@ import {
 } from ".";
 import { StoreSummary, TweetEntity } from "../contract";
 import { asNumberComparable, bigIntToStringReviver } from "../util";
-const JSONBig: {
-  stringify: typeof JSON.stringify;
-  parse: typeof JSON.parse;
-} = require("json-bigint");
+
+const JSONBigImpl = JSONBig({ useNativeBigInt: true });
 
 export const init = (
   readTweetFile?: string,
@@ -53,7 +52,7 @@ const fetch = (fileName: string) => async (
         return;
       }
       try {
-        const json: Array<TweetEntity> = JSONBig.parse(data);
+        const json: Array<TweetEntity> = JSONBigImpl.parse(data);
         const lessThanCompare = asNumberComparable(since_id ?? "0").lt;
         resolve(json.filter((entity) => lessThanCompare(entity.id_str)));
       } catch (e) {

--- a/src/infrastructure/file.ts
+++ b/src/infrastructure/file.ts
@@ -10,7 +10,7 @@ import {
   nopStoreSummaries,
 } from ".";
 import { StoreSummary, TweetEntity } from "../contract";
-import { asNumberComparable } from "../util";
+import { asNumberComparable, bigIntToStringReviver } from "../util";
 const JSONBig: {
   stringify: typeof JSON.stringify;
   parse: typeof JSON.parse;
@@ -109,7 +109,7 @@ const storeJsonStringEntries = (fileName: string) => async (
   return new Promise((resolve, reject) => {
     writeFile(
       fileName,
-      entities.map((e) => JSONBig.stringify(e)).join("\n"),
+      entities.map((e) => JSON.stringify(e, bigIntToStringReviver)).join("\n"),
       {
         encoding: "utf-8",
         flag: "a",

--- a/src/infrastructure/spreadsheet.ts
+++ b/src/infrastructure/spreadsheet.ts
@@ -9,6 +9,7 @@ import {
   nopStoreSummaries,
 } from ".";
 import { StoreSummary, TweetEntity } from "../contract";
+import { bigIntToStringReviver } from "../util";
 
 type Credentials = Parameters<
   GoogleApis["auth"]["OAuth2"]["prototype"]["setCredentials"]
@@ -120,14 +121,7 @@ const storeJsonStringEntries = (
         valueInputOption: "USER_ENTERED",
         requestBody: {
           values: summaries
-            .map((v) => [
-              JSON.stringify(v, (_, value) => {
-                if (typeof value === "bigint") {
-                  return value.toString();
-                }
-                return value;
-              }),
-            ])
+            .map((v) => [JSON.stringify(v, bigIntToStringReviver)])
             .reverse(),
         },
       },

--- a/src/util.ts
+++ b/src/util.ts
@@ -109,3 +109,13 @@ const asNumberComparableImpl = (
 
   return compareCharNumber(trimmedBase, trimmedCompareValue, 0, op);
 };
+
+export const bigIntToStringReviver = (
+  _key: string,
+  value: unknown
+): unknown => {
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  return value;
+};


### PR DESCRIPTION
ref: https://github.com/sidorares/json-bigint/issues/34

Azure Functions上でも同様の事が再現したため、stringifyは自前で行ってparseだけに制限する